### PR TITLE
fix: get dialpad tones enabled from settings and volume can be default

### DIFF
--- a/lib/dtmf.dart
+++ b/lib/dtmf.dart
@@ -18,6 +18,9 @@ class Dtmf {
     if (samplingRate == null) {
       samplingRate = 500;
     }
+    if (durationMs == null) {
+      durationMs = 160;
+    }
     final Map<String, Object?> args = <String, dynamic>{
       "digits": digits,
       "samplingRate": samplingRate,


### PR DESCRIPTION
The main purpose of this PR is to get the system settings of the Dialpad enabled/disabled keypad tones.
What has been done:
- Get Android Dialpad settings for tones enabled/disabled
- Create tone generator based on system settings or user settings
- Release tone generator when no longer needed
- As durationMS is nullable, set a default value if it is