### PR TITLE
Fix issues 15 & 17 and Clean for V 3.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## 3.0.2
+* Revert Fix introduced in 3.0.1 which has been deleted in 3.0.2
+* Fix issue  : "AUDIO_OUTPUT_FLAG_FAST denied by server"
+* Added the option to force play sounds, even if DTMF sound are disabled in settings
+
+## 3.0.2
 * Fix Android Volume System Default
 
 ## 3.0.1

--- a/android/src/main/kotlin/com/eopeter/flutter_dtmf/DtmfPlugin.kt
+++ b/android/src/main/kotlin/com/eopeter/flutter_dtmf/DtmfPlugin.kt
@@ -1,5 +1,4 @@
 package com.eopeter.flutter_dtmf
-
 import android.content.Context
 import android.media.ToneGenerator
 import android.media.AudioManager
@@ -14,122 +13,135 @@ import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
 import io.flutter.plugin.common.PluginRegistry.Registrar
 
-
 class DtmfPlugin : FlutterPlugin, MethodCallHandler {
 
-  override fun onAttachedToEngine(binding: FlutterPlugin.FlutterPluginBinding) {
-    setUpChannels(binding.binaryMessenger)
-    applicationContext = binding.applicationContext
-    audioManager = applicationContext.getSystemService(Context.AUDIO_SERVICE) as AudioManager
-    toneGenerator = ToneGenerator(AudioManager.STREAM_SYSTEM, ToneGenerator.MAX_VOLUME / 2)
-  }
-  
-  companion object {
-
-    var channel: MethodChannel? = null
-    private lateinit var applicationContext: Context
-    private lateinit var audioManager: AudioManager
-    private var toneGenerator: ToneGenerator? = null
-
-    @JvmStatic
-    fun registerWith(registrar: Registrar) {
-      setUpChannels(registrar.messenger())
+    override fun onAttachedToEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+        setUpChannels(binding.binaryMessenger)
+        applicationContext = binding.applicationContext
+        audioManager = applicationContext.getSystemService(Context.AUDIO_SERVICE) as AudioManager
     }
-    
-    fun setUpChannels(messenger: BinaryMessenger){
-      channel = MethodChannel(messenger, "flutter_dtmf")
-      channel?.setMethodCallHandler(DtmfPlugin())
-    }
-  }
 
-  override fun onMethodCall(call: MethodCall, result: Result) {
-    val arguments = call.arguments as? Map<*, *>
-
-    if (call.method == "getPlatformVersion") {
-      result.success("Android ${android.os.Build.VERSION.RELEASE}")
-    }
-    else if (call.method == "playTone")
-    {
-      val digits = arguments?.get("digits") as? String
-      val samplingRate = arguments?.get("samplingRate") as? Float
-      val durationMs = arguments?.get("durationMs") as? Int
-      val volume = arguments?.get("volume") as? Double
-
-      if (digits != null) {
-        playTone(digits.trim(), durationMs as Int, volume)
-        result.success(true)
-      }
-    }
-    else {
-      result.notImplemented()
-    }
-  }
-
-    private fun playTone(digits: String, durationMs: Int, volume: Double?) {
-        var isDtmfToneDisabled = false;
-
-        try {
-            isDtmfToneDisabled = Settings.System.getInt(
-                applicationContext.contentResolver,
-                Settings.System.DTMF_TONE_WHEN_DIALING, 1
-            ) == 0;
-        } catch (e: Settings.SettingNotFoundException) {
-            Log.e("DTMFPlugin", e.toString())
+    companion object {
+        var channel: MethodChannel? = null
+        private lateinit var applicationContext: Context
+        private lateinit var audioManager: AudioManager
+        @JvmStatic
+        fun registerWith(registrar: Registrar) {
+            setUpChannels(registrar.messenger())
         }
-        if (toneGenerator == null || isDtmfToneDisabled) {
-            return;
+        fun setUpChannels(messenger: BinaryMessenger) {
+            channel = MethodChannel(messenger, "flutter_dtmf")
+            channel?.setMethodCallHandler(DtmfPlugin())
         }
+    }
 
-        if (volume != null) {
-            val streamType = AudioManager.STREAM_DTMF
-            val maxVolume = audioManager.getStreamMaxVolume(streamType)
-            // Set the volume level as a percentage
-            var targetVolume = volume * maxVolume
-            audioManager.setStreamVolume(streamType, targetVolume.toInt(), 0)
-            // Adjust volume using AudioManager
-            toneGenerator = ToneGenerator(streamType, targetVolume.toInt())
-        }
+    override fun onMethodCall(call: MethodCall, result: Result) {
+        val arguments = call.arguments as? Map<*, *>
 
-        Thread {
-            for (i in digits.indices) {
-                val toneType = getToneType(digits[i].toString())
-                if (toneType != -1)
-                    toneGenerator?.startTone(toneType, durationMs)
-                Thread.sleep((durationMs + 80).toLong())
+        if (call.method == "getPlatformVersion") {
+            result.success("Android ${android.os.Build.VERSION.RELEASE}")
+        } else if (call.method == "playTone") {
+            val digits = arguments?.get("digits") as? String
+            val samplingRate = arguments?.get("samplingRate") as? Float
+            val durationMs = arguments?.get("durationMs") as? Int
+            val volume = arguments?.get("volume") as Double
+            val ignoreDtmfSystemSettings = arguments?.get("ignoreDtmfSystemSettings") as Boolean
+            val forceMaxVolume = arguments?.get("forceMaxVolume") as Boolean
+            if (digits != null) {
+                playTone(
+                    digits.trim(),
+                    durationMs as Int,
+                    volume,
+                    ignoreDtmfSystemSettings,
+                    forceMaxVolume
+                )
+                result.success(true)
             }
-        }.start()
+        } else {
+            result.notImplemented()
+        }
     }
 
-  private fun getToneType(digit: String): Int {
-    when(digit) {
-      "0" -> return ToneGenerator.TONE_DTMF_0
-      "1" -> return ToneGenerator.TONE_DTMF_1
-      "2" -> return ToneGenerator.TONE_DTMF_2
-      "3" -> return ToneGenerator.TONE_DTMF_3
-      "4" -> return ToneGenerator.TONE_DTMF_4
-      "5" -> return ToneGenerator.TONE_DTMF_5
-      "6" -> return ToneGenerator.TONE_DTMF_6
-      "7" -> return ToneGenerator.TONE_DTMF_7
-      "8" -> return ToneGenerator.TONE_DTMF_8
-      "9" -> return ToneGenerator.TONE_DTMF_9
-      "*" -> return ToneGenerator.TONE_DTMF_S
-      "#" -> return ToneGenerator.TONE_DTMF_P
-      "A" -> return ToneGenerator.TONE_DTMF_A
-      "B" -> return ToneGenerator.TONE_DTMF_B
-      "C" -> return ToneGenerator.TONE_DTMF_C
-      "D" -> return ToneGenerator.TONE_DTMF_D
+    private fun playTone(
+        digits: String,
+        durationMs: Int,
+        volume: Double,
+        ignoreDtmfSystemSettings: Boolean,
+        forceMaxVolume: Boolean
+    ) {
+
+        if (!ignoreDtmfSystemSettings) {
+            var isDtmfToneDisabled = false
+
+            try {
+                isDtmfToneDisabled = Settings.System.getInt(
+                    applicationContext.contentResolver,
+                    Settings.System.DTMF_TONE_WHEN_DIALING, 1
+                ) == 0;
+            } catch (e: Settings.SettingNotFoundException) {
+                Log.e("DTMFPlugin", e.toString())
+            }
+            if (isDtmfToneDisabled) {
+                Log.i(
+                    "DTMFPlugin",
+                    "No sound is played : Dtmf Tone is disabled on device and not ignored."
+                )
+                return;
+            }
+        }
+
+        val streamType = AudioManager.STREAM_DTMF
+
+        var maxVolume = audioManager.getStreamMaxVolume(streamType)
+        if (forceMaxVolume) {
+            maxVolume = 100
+        }
+        // Set the volume level as a percentage
+        var targetVolume = volume * maxVolume
+        audioManager.setStreamVolume(streamType, targetVolume.toInt(), 0)
+        // Adjust volume using AudioManager
+        var toneGenerator = ToneGenerator(streamType, targetVolume.toInt())
+
+
+        Thread(object : Runnable {
+            override fun run() {
+                for (i in digits.indices) {
+                    val toneType = getToneType(digits[i].toString())
+                    if (toneType != -1)
+                        toneGenerator?.startTone(toneType, durationMs)
+                    Thread.sleep((durationMs + 80).toLong())
+                }
+                toneGenerator.release(); //Is needed to be able to play at high frequency !
+            }
+        }).start()
     }
 
-    return -1
-  }
-  
-  override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
-    channel?.setMethodCallHandler(null)
-    channel = null
-      if(toneGenerator!= null){
-          toneGenerator?.release()
-      }
-  }
+    private fun getToneType(digit: String): Int {
+        when (digit) {
+            "0" -> return ToneGenerator.TONE_DTMF_0
+            "1" -> return ToneGenerator.TONE_DTMF_1
+            "2" -> return ToneGenerator.TONE_DTMF_2
+            "3" -> return ToneGenerator.TONE_DTMF_3
+            "4" -> return ToneGenerator.TONE_DTMF_4
+            "5" -> return ToneGenerator.TONE_DTMF_5
+            "6" -> return ToneGenerator.TONE_DTMF_6
+            "7" -> return ToneGenerator.TONE_DTMF_7
+            "8" -> return ToneGenerator.TONE_DTMF_8
+            "9" -> return ToneGenerator.TONE_DTMF_9
+            "*" -> return ToneGenerator.TONE_DTMF_S
+            "#" -> return ToneGenerator.TONE_DTMF_P
+            "A" -> return ToneGenerator.TONE_DTMF_A
+            "B" -> return ToneGenerator.TONE_DTMF_B
+            "C" -> return ToneGenerator.TONE_DTMF_C
+            "D" -> return ToneGenerator.TONE_DTMF_D
+        }
+
+        return -1
+    }
+    override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+        channel?.setMethodCallHandler(null)
+        channel = null
+    }
 
 
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -33,7 +33,9 @@ class _MyAppState extends State<MyApp> {
                 digits: "#1234567890*",
                 samplingRate: 8000,
                 durationMs: 160,
-                volume: 0.8);
+                volume: 0.8,
+                ignoreDtmfSystemSettings:true,
+            forceMaxVolume: true);
           },
         )),
       ),

--- a/lib/dtmf.dart
+++ b/lib/dtmf.dart
@@ -9,24 +9,25 @@ class Dtmf {
   /// at the specified volume. If no volume is specified, the system default is used. Volume value should be between
   /// 0 and 1.
   /// Returns true if tone played successfully
+  /// Set ignoreDtmfSystemSettings to true, if you want to play sound even when dtmf sounds are disable on the device (ex : on a tablet)
+  /// Set forceMaxVolume to true if you want to increase max volume to the max volume of the phone, (and not just max volume of DTMF sounds).
+  /// If you force max Volume to true, you can still control the volume with the volume atribute.
   ///
   static Future<bool?> playTone(
       {required String digits,
-      int? durationMs,
-      double? samplingRate,
-      double? volume}) async {
-    if (samplingRate == null) {
-      samplingRate = 500;
-    }
-    if (durationMs == null) {
-      durationMs = 160;
-    }
+      int durationMs =160,
+      double samplingRate =500,
+      double volume = 1,
+      bool ignoreDtmfSystemSettings=false,
+      bool forceMaxVolume=false}) async {
+
     final Map<String, Object?> args = <String, dynamic>{
       "digits": digits,
       "samplingRate": samplingRate,
       "durationMs": durationMs,
-      "volume": volume
-    };
+      "volume": volume,
+      "ignoreDtmfSystemSettings":ignoreDtmfSystemSettings,
+      "forceMaxVolume":forceMaxVolume};
     return await _channel.invokeMethod('playTone', args);
   }
 }

--- a/lib/dtmf_method_channel.dart
+++ b/lib/dtmf_method_channel.dart
@@ -17,14 +17,18 @@ class MethodChannelDtmf extends DtmfPlatform {
   @override
   Future<bool> playTone(
       {required String digits,
-      int? durationMs,
-      double? samplingRate,
-      double? volume}) async {
+      int durationMs=160,
+      double samplingRate=500,
+      double volume=1,
+      bool ignoreDtmfSystemSettings = false,
+      bool forceMaxVolume = false}) async {
     final Map<String, Object?> args = <String, dynamic>{
       "digits": digits,
       "samplingRate": samplingRate,
       "durationMs": durationMs,
-      "volume": volume
+      "volume": volume,
+      "ignoreDtmfSystemSettings":ignoreDtmfSystemSettings,
+      "forceMaxVolume":forceMaxVolume
     };
     return await methodChannel.invokeMethod('playTone', args);
   }

--- a/lib/dtmf_platform_interface.dart
+++ b/lib/dtmf_platform_interface.dart
@@ -27,9 +27,11 @@ abstract class DtmfPlatform extends PlatformInterface {
 
   Future<bool> playTone(
       {required String digits,
-      int? durationMs,
-      double? samplingRate,
-      double? volume}) {
+      int durationMs=160,
+      double samplingRate=500,
+      double volume=1,
+      bool ignoreDtmfSystemSettings = false,
+      bool forceMaxVolume = false}) {
     throw UnimplementedError('playTone() has not been implemented.');
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_dtmf
 description: Generates DTFM Tones for Flutter Application. This can be used in VOIP applications or other applications that need to generate DTMF Tones.
-version: 3.0.2
+version: 3.0.3
 homepage: "https://www.eopeter.com"
 repository: "https://github.com/eopeter/flutter_dtmf"
 


### PR DESCRIPTION
With a litlle more work I fixed the issue https://github.com/eopeter/flutter_dtmf/issues/17 and https://github.com/eopeter/flutter_dtmf/issues/15 .

I also put back the tonegenerator release() at the end of each call to play sound, and not in onDetachedFrom engine.
Please do not remove otherwise it does not work on my usecase (high frequency).

- Set ignoreDtmfSystemSettings to true, if you want to play sound even when dtmf sounds are disable on the device (ex : on a tablet). Is set to false by default.

- Set forceMaxVolume to true if you want to increase max volume to the max volume of the phone, (and not just max volume of DTMF sounds). Is set to false by default.

- If you force max Volume to true, you can still control the volume with the volume atribute.