### PR TITLE
Remove deprecated registrar

### DIFF
--- a/android/src/main/kotlin/com/eopeter/flutter_dtmf/DtmfPlugin.kt
+++ b/android/src/main/kotlin/com/eopeter/flutter_dtmf/DtmfPlugin.kt
@@ -11,7 +11,6 @@ import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
-import io.flutter.plugin.common.PluginRegistry.Registrar
 
 class DtmfPlugin : FlutterPlugin, MethodCallHandler {
 
@@ -25,10 +24,7 @@ class DtmfPlugin : FlutterPlugin, MethodCallHandler {
         var channel: MethodChannel? = null
         private lateinit var applicationContext: Context
         private lateinit var audioManager: AudioManager
-        @JvmStatic
-        fun registerWith(registrar: Registrar) {
-            setUpChannels(registrar.messenger())
-        }
+
         fun setUpChannels(messenger: BinaryMessenger) {
             channel = MethodChannel(messenger, "flutter_dtmf")
             channel?.setMethodCallHandler(DtmfPlugin())

--- a/ios/Classes/SwiftDtmfPlugin.swift
+++ b/ios/Classes/SwiftDtmfPlugin.swift
@@ -18,6 +18,12 @@ public class SwiftDtmfPlugin: NSObject, FlutterPlugin {
     }
     
   public static func register(with registrar: FlutterPluginRegistrar) {
+    do {
+      try AVAudioSession.sharedInstance().setCategory(.ambient, mode: .default)
+      try AVAudioSession.sharedInstance().setActive(true)
+    } catch let error as NSError {
+        print("AVAudioSession setCategory failed - \(error)")
+    }
     let channel = FlutterMethodChannel(name: "flutter_dtmf", binaryMessenger: registrar.messenger())
     let instance = SwiftDtmfPlugin()
     registrar.addMethodCallDelegate(instance, channel: channel)


### PR DESCRIPTION
The `registerWith` method, which used the deprecated `PluginRegistry.Registrar`, has been removed. The plugin now solely relies on `setUpChannels` for initialization.